### PR TITLE
Add `--today` and `--tomorrow` flags for hourly forecasts

### DIFF
--- a/cmd/wx/display.go
+++ b/cmd/wx/display.go
@@ -94,7 +94,7 @@ func PrintForecast(report bbcweather.ForecastReport) {
 	w.Flush()
 }
 
-func PrintHourlyForecast(report bbcweather.ForecastReport) {
+func PrintHourlyForecast(report bbcweather.ForecastReport, day string) {
 	if len(report.HourlyForecasts) == 0 {
 		fmt.Println("No hourly forecasts available")
 		return
@@ -113,9 +113,20 @@ func PrintHourlyForecast(report bbcweather.ForecastReport) {
 		titleColor.Sprint(""),
 		titleColor.Sprint("Description"))
 
-	today := time.Now().Day()
+	now := time.Now()
+	var dayToDisplay time.Time
+	switch day {
+	case "today":
+		dayToDisplay = now
+	case "tomorrow":
+		dayToDisplay = now.AddDate(0, 0, 1)
+	default:
+		// Should not happen
+		return
+	}
+
 	for _, hour := range report.HourlyForecasts {
-		if hour.ForecastDate.Day() != today {
+		if hour.ForecastDate.Day() != dayToDisplay.Day() {
 			continue
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",

--- a/cmd/wx/display.go
+++ b/cmd/wx/display.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/codehex/bbcweather"
 	"github.com/fatih/color"
@@ -89,6 +90,40 @@ func PrintForecast(report bbcweather.ForecastReport) {
 			labelColor.Sprintf("%d%%", day.ChanceOfRainPercent),
 			day.WeatherDescription)
 
+	}
+	w.Flush()
+}
+
+func PrintHourlyForecast(report bbcweather.ForecastReport) {
+	if len(report.HourlyForecasts) == 0 {
+		fmt.Println("No hourly forecasts available")
+		return
+	}
+
+	fmt.Println("--------------------------------------------------")
+	fmt.Printf("%s (updated at %s)\n", titleColor.Sprint("Hourly Forecast"), report.DayForecasts[0].LastUpdated.Format("3:04pm"))
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, 1, 3, 3, ' ', 0)
+
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		titleColor.Sprint("Time"),
+		titleColor.Sprint("Temp"),
+		titleColor.Sprint("Wind"),
+		titleColor.Sprint(""),
+		titleColor.Sprint("Description"))
+
+	today := time.Now().Day()
+	for _, hour := range report.HourlyForecasts {
+		if hour.ForecastDate.Day() != today {
+			continue
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			labelColor.Sprint(hour.Timeslot),
+			ColorizeTempC(hour.TemperatureC),
+			ColorizeWindMph(hour.WindSpeedMph, hour.WindCategory),
+			"",
+			hour.Description)
 	}
 	w.Flush()
 }

--- a/cmd/wx/main.go
+++ b/cmd/wx/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -9,7 +10,10 @@ import (
 )
 
 func main() {
-	args := os.Args[1:]
+	today := flag.Bool("today", false, "Show today's hourly forecast")
+	flag.Parse()
+
+	args := flag.Args()
 	data := strings.Join(args, " ")
 	query := os.Getenv("WX_QUERY")
 	if data != "" {
@@ -43,5 +47,9 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	PrintForecast(forecast)
+	if *today {
+		PrintHourlyForecast(forecast)
+	} else {
+		PrintForecast(forecast)
+	}
 }

--- a/cmd/wx/main.go
+++ b/cmd/wx/main.go
@@ -11,6 +11,7 @@ import (
 
 func main() {
 	today := flag.Bool("today", false, "Show today's hourly forecast")
+	tomorrow := flag.Bool("tomorrow", false, "Show tomorrow's hourly forecast")
 	flag.Parse()
 
 	args := flag.Args()
@@ -48,7 +49,9 @@ func main() {
 		os.Exit(1)
 	}
 	if *today {
-		PrintHourlyForecast(forecast)
+		PrintHourlyForecast(forecast, "today")
+	} else if *tomorrow {
+		PrintHourlyForecast(forecast, "tomorrow")
 	} else {
 		PrintForecast(forecast)
 	}


### PR DESCRIPTION
Hey, liked the tool, wanted to use it regularly but often find myself wanting the hourly forecast, which meant going back to the website.

I went with `--today` and `--tomorrow` as it seemed simpler and less code changes then trying to add an additional input argument of something like `hourly`.